### PR TITLE
Pin maturin version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,4 +157,5 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
+          maturin-version: v1.7.1
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
The latest release was failing, apparently due to a bug in Maturin v1.7.2.

This pins the Maturin version to v1.7.1 in our release workflow.

https://github.com/kraken-tech/python-rustfluent/actions/runs/11029344761/job/30632470084

(I performed the release by tagging this branch, and it worked.)

Issue raised with maturin in https://github.com/PyO3/maturin/issues/2228 