### PR TITLE
Tweak type error handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,21 +26,21 @@ repos:
     hooks:
       - id: ruff-lint
         name: "lint Python code with ruff"
-        entry: "ruff check"
+        entry: "ruff check --fix"
         language: system
         types: [python]
         require_serial: true
 
       - id: ruff-format
         name: "check Python formatting with ruff"
-        entry: "ruff format --check"
+        entry: "ruff format"
         language: system
         types: [python]
         require_serial: true
 
       - id: cargo-format
         name: "check Rust formatting"
-        entry: "cargo fmt -- --check"
+        entry: "cargo fmt --"
         language: system
         types: [ rust ]
         require_serial: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Raise TypeError if variable key is not a string.
+
 ## [0.1.0a3] - 2024-09-25
 
 - Limited Fluent variable types to strings and integers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Raise TypeError if variable key is not a string.
+- Fall back to displaying variable name if there is a type issue with a variable.
 
 ## [0.1.0a3] - 2024-09-25
 

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ bundle = rustfluent.Bundle(
 
 `str`: the translated message.
 
+If there is a problem with a passed variable (e.g. it is of the wrong type or an integer that is larger than a
+signed long integer), then the name of the variable will be used instead.
+
 #### Raises
 
 - `ValueError` if the message could not be found or has no translation available.
-- `TypeError` if:
-  - a passed variable name (i.e. a key in the `variables` dict) is not a string.
-  - a passed variable (i.e. a value in the `variables` dict) is not an instance of `str` or `int`.
-  - a passed `int` variable overflows a signed long integer (i.e. it's not in the range -2,147,483,648 to 2,147,483,647).
+- `TypeError` if a passed variable name (i.e. a key in the `variables` dict) is not a string.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ bundle = rustfluent.Bundle(
 #### Raises
 
 - `ValueError` if the message could not be found or has no translation available.
-- `TypeError` if a passed variable is not an instance of `str` or `int`, or if the `int` overflows a signed long
-  integer (i.e. it's not in the range -2,147,483,648 to 2,147,483,647).
+- `TypeError` if:
+  - a passed variable name (i.e. a key in the `variables` dict) is not a string.
+  - a passed variable (i.e. a value in the `variables` dict) is not an instance of `str` or `int`.
+  - a passed `int` variable overflows a signed long integer (i.e. it's not in the range -2,147,483,648 to 2,147,483,647).
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,18 @@ impl Bundle {
 
         if let Some(variables) = variables {
             for variable in variables {
-                let key: String = variable.0.to_string();
+                // Make sure the variable key is a Python string,
+                // raising a TypeError if not.
+                let python_key = variable.0;
+                if !python_key.is_instance_of::<PyString>() {
+                    return Err(PyTypeError::new_err(format!(
+                        "Variable key not a str, got {}.",
+                        python_key
+                    )));
+                }
+                let key = python_key.to_string();
+                // Set the variable value as a string or integer,
+                // raising a TypeError if not.
                 let python_value = variable.1;
                 if python_value.is_instance_of::<PyString>() {
                     args.set(key, python_value.to_string());

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -50,6 +50,21 @@ def test_variables_of_different_types(description, identifier, variables, expect
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "key",
+    (
+        object(),
+        34.3,
+        10,
+    ),
+)
+def test_invalid_variable_keys_raise_type_error(key):
+    bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
+
+    with pytest.raises(TypeError, match="Variable key not a str, got"):
+        bundle.get_translation("hello-user", variables={key: "Bob"})
+
+
 def test_large_python_integers_fail_sensibly():
     bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
 

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -65,24 +65,19 @@ def test_invalid_variable_keys_raise_type_error(key):
         bundle.get_translation("hello-user", variables={key: "Bob"})
 
 
-def test_large_python_integers_fail_sensibly():
-    bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
-
-    with pytest.raises(
-        TypeError, match=re.escape("Integer variable was too large: 1000000000000.")
-    ):
-        bundle.get_translation(
-            "hello-user",
-            variables={"user": 1_000_000_000_000},
-        )
-
-
-@pytest.mark.parametrize("user", (object(), 34.3))
-def test_invalid_type_raises_type_error(user):
+@pytest.mark.parametrize(
+    "value",
+    (
+        object(),
+        34.3,
+        1_000_000_000_000,  # Larger than signed long integer.
+    ),
+)
+def test_invalid_variable_values_raise_type_error(value):
     bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
 
     with pytest.raises(TypeError):
-        bundle.get_translation("hello-user", variables={"user": user})
+        bundle.get_translation("hello-user", variables={"user": value})
 
 
 def test_fr_basic():

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -73,11 +73,12 @@ def test_invalid_variable_keys_raise_type_error(key):
         1_000_000_000_000,  # Larger than signed long integer.
     ),
 )
-def test_invalid_variable_values_raise_type_error(value):
+def test_invalid_variable_values_use_key_instead(value):
     bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
 
-    with pytest.raises(TypeError):
-        bundle.get_translation("hello-user", variables={"user": value})
+    result = bundle.get_translation("hello-user", variables={"user": value})
+
+    assert result == f"Hello, {BIDI_OPEN}user{BIDI_CLOSE}"
 
 
 def test_fr_basic():


### PR DESCRIPTION
Tweaks the way we handle problematic types passed to `bundle.get_translation`, relating to [fluent variables](https://projectfluent.org/fluent/guide/variables.html).

1. If a variable _key_ is not a string, we raise a `TypeError`. Variable keys should be hardcoded in an application, so it's helpful to see it crash.
2. If there is a problem with the passed a variable _value_ , we use the name of the variable in its place. This is consistent with how [Django FTL](https://django-ftl.readthedocs.io/), and is in the spirit of 'something is better than nothing'. Variable values vary at runtime and it's good to be more resilient to problems with these.