### PR TITLE
Use isolating flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Add use_isolating flag.
+
 ## [0.1.0a4] - 2024-09-25
 
 - Raise TypeError if variable key is not a string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0a5] - 2024-09-26
+
 - Add use_isolating flag.
 
 ## [0.1.0a4] - 2024-09-25

--- a/README.md
+++ b/README.md
@@ -84,15 +84,18 @@ bundle = rustfluent.Bundle(
 >>> bundle.get_translation(identifier="hello-world")
 "Hello, world!"
 >>> bundle.get_translation(identifier="hello-user", variables={"user": "Bob"})
+"Hello, \u2068Bob\u2069!"
+>>> bundle.get_translation(identifier="hello-user", variables={"user": "Bob"}, use_isolating=False)
 "Hello, Bob!"
 ```
 
 #### Parameters
 
-| Name         | Type                         | Description                            |
-|--------------|------------------------------|----------------------------------------|
-| `identifier` | `str`                        | The identifier for the Fluent message. |
-| `variables`  | `dict[str, str | int ]`, optional                  | Any [variables](https://projectfluent.org/fluent/guide/variables.html) to be passed to the Fluent message. |
+| Name                 | Type             | Description                                                                                                                                                               |
+|----------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `identifier`         | `str`            | The identifier for the Fluent message.                                                                                                                                    |
+| `variables`          | `dict[str, str   | int ]`, optional                                                                                                                                                          | Any [variables](https://projectfluent.org/fluent/guide/variables.html) to be passed to the Fluent message. |
+| `use_isolating` | `bool`, optional | Whether to insert Unicode Directionality Isolation Marks around placeables, to indicate that their direction may differ from the surrounding message. Defaults to `True`. |
 
 #### Return value
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [tool.bumpversion] section.
-version = "0.1.0a4"
+version = "0.1.0a5"
 dependencies = []
 
 [project.urls]
@@ -133,7 +133,7 @@ filterwarnings = "error"
 [tool.bumpversion]
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [project] section.
-current_version = "0.1.0a4"
+current_version = "0.1.0a5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = []
 [project.urls]
 # See https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet for
 # additional URLs that can be included here.
-repository = "https://github.com/octoenergy/python-rustfluent"
-changelog = "https://github.com/octoenergy/python-rustfluent/blob/main/CHANGELOG.md"
+repository = "https://github.com/kraken-tech/python-rustfluent/"
+changelog = "https://github.com/kraken-tech/python-rustfluent/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,12 +59,15 @@ impl Bundle {
         Ok(Self { bundle })
     }
 
-    #[pyo3(signature = (identifier, variables=None))]
+    #[pyo3(signature = (identifier, variables=None, use_isolating=true))]
     pub fn get_translation(
-        &self,
+        &mut self,
         identifier: &str,
         variables: Option<&Bound<'_, PyDict>>,
+        use_isolating: bool,
     ) -> PyResult<String> {
+        self.bundle.set_use_isolating(use_isolating);
+
         let msg = match self.bundle.get_message(identifier) {
             Some(m) => m,
             None => return Err(PyValueError::new_err(format!("{} not found", identifier))),
@@ -120,6 +123,7 @@ impl Bundle {
                 }
             }
         }
+
         let value = self
             .bundle
             .format_pattern(pattern, Some(&args), &mut errors);

--- a/src/rustfluent.pyi
+++ b/src/rustfluent.pyi
@@ -3,5 +3,8 @@ Variable = str | int
 class Bundle:
     def __init__(self, language: str, ftl_filenames: list[str], strict: bool = False) -> None: ...
     def get_translation(
-        self, identifier: str, variables: dict[str, Variable] | None = None
+        self,
+        identifier: str,
+        variables: dict[str, Variable] | None = None,
+        use_isolating: bool = True,
     ) -> str: ...

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -27,11 +27,23 @@ def test_en_basic_with_named_arguments():
     assert bundle.get_translation("hello-world") == "Hello World"
 
 
-def test_en_with_args():
+def test_en_with_variables():
     bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
     assert (
         bundle.get_translation("hello-user", variables={"user": "Bob"})
         == f"Hello, {BIDI_OPEN}Bob{BIDI_CLOSE}"
+    )
+
+
+def test_en_with_variables_use_isolating_off():
+    bundle = fluent.Bundle("en", [str(data_dir / "en.ftl")])
+    assert (
+        bundle.get_translation(
+            "hello-user",
+            variables={"user": "Bob"},
+            use_isolating=False,
+        )
+        == "Hello, Bob"
     )
 
 


### PR DESCRIPTION
Provides an option to turn off useIsolating when translating a message.

The reason I've exposed this as a flag during translation, rather than as a method to call on the bundle, is to reduce the number of calls across Python to Rust.