### PR TITLE
Correct name of ParserError exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Correct stringified name of ParserError exception.
+
 ## [0.1.0a6] - 2024-11-05
 
 - Render dates in YYYY-MM-DD format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@ use unic_langid::LanguageIdentifier;
 
 use pyo3::create_exception;
 
-create_exception!(rustfluent, PyParserError, pyo3::exceptions::PyException);
+create_exception!(rustfluent, ParserError, pyo3::exceptions::PyException);
 
 #[pymodule]
 fn rustfluent(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Bundle>()?;
-    m.add("ParserError", m.py().get_type_bound::<PyParserError>())?;
+    m.add("ParserError", m.py().get_type_bound::<ParserError>())?;
     Ok(())
 }
 
@@ -43,7 +43,7 @@ impl Bundle {
                 Ok(resource) => resource,
                 Err(error) => {
                     if strict {
-                        return Err(PyParserError::new_err(format!(
+                        return Err(ParserError::new_err(format!(
                             "Error when parsing {}.",
                             file_path
                         )));

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -170,3 +170,7 @@ def test_raises_parser_error_on_file_that_contains_errors_in_strict_mode():
     filename = str(data_dir / "errors.ftl")
     with pytest.raises(fluent.ParserError, match=re.escape(f"Error when parsing {filename}.")):
         fluent.Bundle("fr", [filename], strict=True)
+
+
+def test_parser_error_str():
+    assert str(fluent.ParserError) == "<class 'rustfluent.ParserError'>"


### PR DESCRIPTION
Prior to this commit, a ParserError would be displayed as <class "rustfluent.PyParserError">, which was confusing.