### PR TITLE
Update macos runner to macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-14
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
The macos-12 image is deprecated.

See https://github.com/kraken-tech/python-rustfluent/actions/runs/13028507622