### PR TITLE
Implement comprehensive validation and structured error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "chrono",
  "fluent",
  "fluent-bundle",
+ "fluent-syntax",
  "miette",
  "pyo3",
  "unic-langid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ pyo3 = { version = "0.25.1", features = ["chrono"] }
 fluent = "0.17.0"
 unic-langid = "0.9.6"
 fluent-bundle = "0.16.0"
+fluent-syntax = "0.12.0"
 chrono = "0.4.41"
 miette = { version = "7.6.0", features = ["fancy"] }

--- a/src/rustfluent.pyi
+++ b/src/rustfluent.pyi
@@ -3,13 +3,55 @@ from pathlib import Path
 
 Variable = str | int | date
 
+class ParseErrorDetail:
+    """Parse time: syntax errors in .ftl files (invalid FTL syntax, malformed messages)"""
+
+    message: str
+    line: int
+    column: int
+    byte_start: int
+    byte_end: int
+    filename: str | None
+
+class ValidationError:
+    """Load time: semantic errors during Bundle() init (unknown refs, cycles, duplicate IDs)"""
+
+    error_type: (
+        str  # DuplicateMessageId, UnknownMessage, UnknownTerm, UnknownAttribute, CyclicReference
+    )
+    message: str
+    message_id: str | None
+    reference: str | None
+
+class FormatError:
+    """Runtime: errors during get_translation() (missing variables, invalid variable types)"""
+
+    error_type: str  # MissingVariable, InvalidVariableType
+    message: str
+    message_id: str | None
+    variable_name: str | None
+    expected_type: str | None
+    actual_type: str | None
+
 class Bundle:
     def __init__(
-        self, language: str, ftl_filenames: list[str | Path], strict: bool = False
+        self,
+        language: str,
+        ftl_filenames: list[str | Path],
+        strict: bool = False,
+        validate_references: bool = True,
     ) -> None: ...
     def get_translation(
         self,
         identifier: str,
         variables: dict[str, Variable] | None = None,
         use_isolating: bool = True,
+        errors: list[FormatError] | None = None,
     ) -> str: ...
+    def get_parse_errors(self) -> list[ParseErrorDetail]: ...
+    def get_validation_errors(self) -> list[ValidationError]: ...
+    def get_all_compile_errors(
+        self,
+    ) -> list[tuple[str, ParseErrorDetail | ValidationError]]: ...
+    def get_compile_errors(self) -> list[ValidationError]: ...
+    def get_required_variables(self, identifier: str) -> list[str]: ...

--- a/tests/data/broken_refs.ftl
+++ b/tests/data/broken_refs.ftl
@@ -1,0 +1,3 @@
+# This has unknown references
+msg-with-unknown-ref = Hello { $var } and { unknown-message }
+another-msg = Value

--- a/tests/data/broken_terms.ftl
+++ b/tests/data/broken_terms.ftl
@@ -1,0 +1,13 @@
+# File with broken term references for testing validation
+
+-valid-term = This is a valid term
+    .case = nominative
+
+# Message references non-existent term
+broken-reference = This references { -nonexistent-term }
+
+# Message uses non-existent term attribute as selector
+broken-attribute = { -valid-term.nonexistent ->
+    [value] Something
+   *[other] Other
+}

--- a/tests/data/cycle.ftl
+++ b/tests/data/cycle.ftl
@@ -1,0 +1,3 @@
+# This has a cyclic reference
+msg-a = Value: { msg-b }
+msg-b = Value: { msg-a }

--- a/tests/data/duplicates.ftl
+++ b/tests/data/duplicates.ftl
@@ -1,0 +1,3 @@
+hello = First definition
+hello = Second definition (duplicate)
+goodbye = Farewell

--- a/tests/data/mixed_errors.ftl
+++ b/tests/data/mixed_errors.ftl
@@ -1,0 +1,10 @@
+# File with both parse errors and validation errors
+
+# This is a parse error - missing =
+invalid-syntax
+
+# This is valid but references unknown message
+valid-with-bad-ref = Check { unknown-msg }
+
+# This is valid
+good-message = This is fine

--- a/tests/data/term_positional_args.ftl
+++ b/tests/data/term_positional_args.ftl
@@ -1,0 +1,13 @@
+-brand-name = { $case ->
+   *[nominative] Firefox
+    [locative] Firefoxie
+}
+
+# This message uses a positional argument to a term (which is ignored per spec)
+bad-reference = Visit { -brand-name("positional") } for more info.
+
+# This message uses both positional and named arguments
+bad-reference-mixed = About { -brand-name("ignored", case: "locative") }.
+
+# This is the correct way - only named arguments
+good-reference = About { -brand-name(case: "locative") }.

--- a/tests/data/terms.ftl
+++ b/tests/data/terms.ftl
@@ -1,0 +1,15 @@
+# Test file with Fluent terms
+-brand-name = Acme Corporation
+
+-product-name = Super Widget
+    .category = gadget
+
+# Messages that reference terms
+welcome = Welcome to { -brand-name }!
+product-info = Learn about { -product-name }
+
+# Message using term attribute as selector (this is valid per Fluent spec)
+product-category = { -product-name.category ->
+    [gadget] This is a gadget
+   *[other] This is something else
+}

--- a/tests/data/terms_definitions.ftl
+++ b/tests/data/terms_definitions.ftl
@@ -1,0 +1,12 @@
+# Term definitions file
+# These terms can be referenced from other files
+
+-app-name = SuperApp
+
+-app-type =
+    { $type ->
+        [mobile] Mobile App
+       *[web] Web App
+    }
+
+-company-name = Acme Corporation

--- a/tests/data/terms_messages.ftl
+++ b/tests/data/terms_messages.ftl
@@ -1,0 +1,6 @@
+# Messages that reference terms from terms_definitions.ftl
+
+about-app = About { -app-name }
+app-title = { -app-name } - The Best App
+app-description = This is a { -app-type(type: "web") }
+company-info = Brought to you by { -company-name }

--- a/tests/data/variables.ftl
+++ b/tests/data/variables.ftl
@@ -1,0 +1,22 @@
+# Messages for testing variable extraction and validation
+
+# Simple message with one variable
+greeting = Hello, { $name }!
+
+# Message with multiple variables
+user-info = { $username } has { $count } messages
+
+# Message with no variables
+static-message = This has no variables
+
+# Message with nested variables in selector
+item-status = { $count ->
+    [0] No items for { $user }
+    [1] One item for { $user }
+   *[other] { $count } items for { $user }
+}
+
+# Message attribute with variables
+email-template = Send email
+    .subject = Hello { $recipient }
+    .body = You have { $messageCount } new messages

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -844,7 +844,7 @@ def test_validate_references_false_with_duplicates():
 def test_get_translation_errors_missing_variable():
     """Test that missing variables are reported via errors parameter."""
     bundle = fluent.Bundle("en", [data_dir / "variables.ftl"])
-    errors = []
+    errors: list[fluent.FormatError] = []
 
     # Call get_translation without providing required variable
     result = bundle.get_translation("greeting", errors=errors)
@@ -864,11 +864,13 @@ def test_get_translation_errors_missing_variable():
 def test_get_translation_errors_invalid_variable_type():
     """Test that invalid variable types are reported via errors parameter."""
     bundle = fluent.Bundle("en", [data_dir / "variables.ftl"])
-    errors = []
+    errors: list[fluent.FormatError] = []
 
     # Pass a list instead of a string
     result = bundle.get_translation(
-        "greeting", variables={"name": ["not", "a", "string"]}, errors=errors
+        "greeting",
+        variables={"name": ["not", "a", "string"]},  # type: ignore[dict-item]
+        errors=errors,
     )
 
     # Result should use fallback (the variable key itself)
@@ -887,7 +889,7 @@ def test_get_translation_errors_invalid_variable_type():
 def test_get_translation_errors_multiple_missing_variables():
     """Test that multiple missing variables are all reported."""
     bundle = fluent.Bundle("en", [data_dir / "variables.ftl"])
-    errors = []
+    errors: list[fluent.FormatError] = []
 
     # user-info needs both $username and $count
     result = bundle.get_translation("user-info", errors=errors)
@@ -906,7 +908,7 @@ def test_get_translation_errors_multiple_missing_variables():
 def test_get_translation_errors_partial_variables():
     """Test errors when only some variables are provided."""
     bundle = fluent.Bundle("en", [data_dir / "variables.ftl"])
-    errors = []
+    errors: list[fluent.FormatError] = []
 
     # Provide only username, not count
     result = bundle.get_translation("user-info", variables={"username": "Alice"}, errors=errors)
@@ -932,7 +934,7 @@ def test_get_translation_errors_none_parameter():
 def test_get_translation_errors_with_attributes():
     """Test error collection with message attributes."""
     bundle = fluent.Bundle("en", [data_dir / "variables.ftl"])
-    errors = []
+    errors: list[fluent.FormatError] = []
 
     # email-template.subject needs $recipient
     result = bundle.get_translation("email-template.subject", errors=errors)


### PR DESCRIPTION
  ## Summary

  This PR transforms error handling from basic parse errors into a comprehensive validation system that catches errors at compile-time (file load) and runtime (message formatting), with structured error objects for programmatic access.

  ## Motivation

  Previously, `rustfluent` only reported syntax errors during parsing. Semantic issues like broken references, cycles, or missing variables were only caught at runtime during message formatting, making debugging difficult. This PR adds comprehensive compile-time validation and structured error reporting.

  ## Changes

  ### 1. Structured Error Classes

  Three new Python-accessible error types:

  **`ParseErrorDetail`** - Syntax errors from FTL parsing
  - `message`: Error description only (e.g., 'Expected a token starting with "="')
  - `line`, `column`: 1-indexed location
  - `byte_start`, `byte_end`: 0-indexed byte offsets
  - `filename`: Optional file path
  - `__str__()` format: `file.ftl:12:5: Expected token starting with "="`
  - `__repr__()` format: `ParseErrorDetail(message='...', line=12, column=5, ...)`

  **`ValidationError`** - Semantic errors found during validation
  - `error_type`: Category (`UnknownMessage`, `UnknownTerm`, `CyclicReference`, etc.)
  - `message`: Human-readable description
  - `message_id`: Which message contains the error
  - `reference`: What was being referenced (if applicable)

  **`FormatError`** - Runtime formatting errors
  - `error_type`: Category (`MissingVariable`, `InvalidVariableType`, etc.)
  - `message`, `message_id`, `variable_name`
  - `expected_type`, `actual_type`: For type mismatches

  ### 2. Compile-Time Validation System

  New validation logic runs when loading FTL files (in `Bundle.__init__`):

  ✅ **Reference validation**
  - Checks that message references like `{ other-message }` exist
  - Checks that term references like `{ -brand-name }` exist
  - Validates message and term attribute references
    - First validates that the message/term exists
    - Then validates that the specific attribute exists on it
    - Message attributes: `{ message.attr }` (usable as placeable or selector)
    - Term attributes: `{ -term.attr -> ... }` (usable as selector only, per Fluent spec)
> Note: Direct term attribute placeables like `{ -term.attr }` are rejected by the Fluent parser itself before validation runs.
  - Works across multiple files

  ✅ **Cycle detection**
  - DFS-based algorithm detects circular references
  - Reports full cycle path: `msg1 -> msg2 -> msg3 -> msg1`

  ✅ **Duplicate detection**
  - Warns when message/term IDs are redefined
  - Checks both within files and across files

  ✅ **Term validation**
  - Warns when positional args passed to terms (per Fluent spec, these are ignored)
  - Example: `{ -term("ignored") }` generates warning to use named args instead

  ### 3. Enhanced Bundle API

  **New constructor parameter:**
  ```diff
- Bundle(language, files, strict=False)
  + Bundle(language, files, strict=False, validate_references=True)
```
  New inspection methods:
```python
  bundle.get_parse_errors() -> List[ParseErrorDetail]
  bundle.get_validation_errors() -> List[ValidationError]
  bundle.get_all_compile_errors() -> List[Tuple[str, Union[ParseErrorDetail, ValidationError]]]
  bundle.get_required_variables(identifier) -> List[str]  # New: lists variables for a message
```
 ### 4. Improved Error Handling Behavior

  Before:
  - Strict mode raised error on first parse error in first file
  - No validation of references, cycles, or duplicates
  - Runtime errors had minimal context

  After:
  - Collects ALL errors from ALL files before raising
  - Validation errors collected alongside parse errors
  - In strict mode, raises comprehensive error with all issues using `miette` formatting
  - In non-strict mode, stores errors on Bundle for programmatic access
  - Runtime errors include message ID, variable name, and type information

  ### 5. Runtime Validation Enhancements

  The `get_translation()` method now:
  - Detects missing variables and reports as `FormatError`
  - Enhanced type checking with expected vs actual type reporting
  - All errors collected in the optional errors parameter list

  ## Example Usage

  Accessing structured errors in strict mode:
```python
try:
    bundle = Bundle("en", ["errors.ftl"], strict=True)
except ParserError as e:
    # Pretty miette output shows all errors
    print(e)

    # Programmatic access to individual errors
    for error in e.parse_errors:
        print(f"{error.filename}:{error.line}:{error.column}: {error.message}")

    for error in e.validation_errors:
        print(f"{error.error_type} in '{error.message_id}': {error.message}")
```
  Inspecting errors in non-strict mode:
```python
bundle = Bundle("en", ["app.ftl"])

# Check for any compile-time errors
for error in bundle.get_validation_errors():
    if error.error_type == "UnknownMessage":
        print(f"Broken reference in {error.message_id}: {error.reference}")
```
  Checking required variables:
```python
vars = bundle.get_required_variables("welcome")
# Returns: ["user", "count"]
```

  Runtime error handling:
```python
errors = []
result = bundle.get_translation("hello", {"count": 5}, errors=errors)
for error in errors:
    if error.error_type == "MissingVariable":
        print(f"Missing: {error.variable_name}")
```
##  Implementation Details

  - Added `fluent-syntax` dependency for AST traversal
  - Separate term tracking index (`HashMap<String, TermInfo>`) fixes term validation
  - `byte_pos_to_line_col()` helper converts byte offsets to line/column
  - AST walking functions recursively traverse patterns, expressions, selectors, variants
  - Cycle detection uses DFS with visited set and path tracking
  - Comprehensive error creation uses `miette` for pretty formatting with labeled spans

##  Breaking Changes

  None. This is fully backward compatible:
  - Existing code continues to work unchanged
  - New `validate_references` parameter defaults to `True`
  - New methods are additions, not replacements
  - Error handling behavior improves but doesn't break existing exception handling

##  Test Coverage

  - ✅ Structured ParseErrorDetail access and fields
  - ✅ Unknown message/term/attribute validation
  - ✅ Cycle detection
  - ✅ Duplicate detection
  - ✅ Term positional argument warnings
  - ✅ Cross-file term references
  - ✅ Both strict and non-strict modes
  - ✅ Runtime variable validation