### PR TITLE
Add python 3.14 to cicd test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
           cache: 'pip'
           cache-dependency-path: |
             pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Officially support Python 3.14.
 - Add support for Fluent message attributes via dot notation (e.g., `bundle.get_translation("message.attribute")`).
 
 ## [0.1.0a8] - 2025-10-01

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This package supports:
 - Python 3.11
 - Python 3.12
 - Python 3.13
+- Python 3.14
 
 ## Installation
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,7 @@ nox.options.default_venv_backend = "uv"
         nox.param("3.11", id="python=3.11"),
         nox.param("3.12", id="python=3.12"),
         nox.param("3.13", id="python=3.13"),
+        nox.param("3.14", id="python=3.14"),
     ],
 )
 def tests(session: nox.Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
 ]
 # Do not manually edit the version, use `make version_{type}` instead.


### PR DESCRIPTION
The new pyo3 lib supports python 3.14 now. In order to unblock potentially python upgrades for users of the lib the test matrix is extended to use python 3.14 too.

<img width="624" height="345" alt="image" src="https://github.com/user-attachments/assets/8366065e-0179-499d-a04e-d4b91f46f73e" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215746382117759